### PR TITLE
fix mpv-release tag

### DIFF
--- a/.github/workflows/mpv_clang.yml
+++ b/.github/workflows/mpv_clang.yml
@@ -106,7 +106,7 @@ jobs:
           ninja -C build_$BIT update
           ninja -C build_$BIT llvm-copy-builtin
           $MPV_TARBALL && ninja -C build_$BIT mpv-release || ninja -C build_$BIT mpv
-          $MPV_TARBALL && echo "mpv_ver=$(cat build_$BIT/packages/mpv-release-prefix/VERSION)" >> $GITHUB_OUTPUT || echo "mpv_ver=$(cat build_$BIT/$BIT-w64-mingw32/mpv-version.h | grep -oP '#define VERSION "(\K[^"]+)')" >> $GITHUB_OUTPUT
+          $MPV_TARBALL && echo "mpv_ver=$(cat build_$BIT/packages/mpv-release-prefix/MPV_VERSION)" >> $GITHUB_OUTPUT || echo "mpv_ver=$(cat build_$BIT/$BIT-w64-mingw32/mpv-version.h | grep -oP '#define VERSION "(\K[^"]+)')" >> $GITHUB_OUTPUT
 
       - name: Packaging mpv
         run: |


### PR DESCRIPTION
Due to this change https://github.com/shinchiro/mpv-winbuild-cmake/commit/6f8eb391aa1a90ebba04db5c79fdeee7a2696f0e, The release tag cannot be obtained.